### PR TITLE
FV(c) v FA(c)

### DIFF
--- a/03-dokazovanje-pravilnosti/03-dokazovanje-pravilnosti.md
+++ b/03-dokazovanje-pravilnosti/03-dokazovanje-pravilnosti.md
@@ -218,11 +218,11 @@ Pravilo za popolno pravilnost `while` se glasi:
 
 Naj bo `e` količina, ki se ne more v nedogled zmanjševati (na primer naravno število):
 
-     [ P ∧ b ∧ e = z ] c [P ∧ e < z ]        z ∉ FV(c)
+     [ P ∧ b ∧ e = z ] c [P ∧ e < z ]        z ∉ FA(c)
      ————————————————————————————————————————————————
           [ P ] while b do c done [ ¬ b ∧ P ]
 
-V tem pravilu je `z` duh, kar formalno napišemo kot `z ∉ FV(c)`.
+V tem pravilu je `z` duh, kar formalno napišemo kot `z ∉ FA(c)`.
 Kako pa ta pravila v praksi uporabljamo? Poglejmo nekaj primerov.
 
 


### PR DESCRIPTION
Na koncu popolne pravilnosti pred primeri sem FV(C) dvakrat popravil na FA(c), ker ste ves čas pred tem pisali FV(P) in FA(c), tako da je FV(c) izgledalo kot tipkarska napaka. 

Lep pozdrav
Primož Zidanšek,
študent 2. letnika FRI pri PPJ